### PR TITLE
Don't .gitignore wrangler file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 .alchemy
-wrangler.jsonc
 .vscode/settings.json
 .wrangler
 .claude/*.local.json

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "name": "sideprojectsaturday",
+  "main": "dist/_worker.js/index.js",
+  "compatibility_date": "2025-07-01",
+  "compatibility_flags": [
+    "nodejs_compat_v2",
+    "nodejs_compat_populate_process_env"
+  ],
+  "assets": { "binding": "ASSETS", "directory": "dist" },
+  "vars": {
+    "BETTER_AUTH_BASE_URL": "https://sideprojectsaturday.just-be.workers.dev"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_id": "9392bb26-e437-40ea-81cb-9d790bb62920",
+      "database_name": "sps-db",
+      "migrations_dir": "prisma/migrations",
+      "preview_database_id": "9392bb26-e437-40ea-81cb-9d790bb62920"
+    }
+  ]
+}


### PR DESCRIPTION
## Add Wrangler configuration for Cloudflare Workers deployment

This PR adds a `wrangler.jsonc` configuration file and removes it from `.gitignore` to enable direct deployment to Cloudflare Workers.

### Changes:
- **Added `wrangler.jsonc`**: Configures the Cloudflare Workers deployment with:
  - D1 database binding for the SQLite database
  - Node.js compatibility flags required for the Astro SSR application
  - Environment variables including the production URL
  - Assets binding for serving static files from the Astro build
- **Updated `.gitignore`**: Removed `wrangler.jsonc` from gitignore to track this configuration in version control

This allows developers to deploy the application directly using Wrangler CLI as an alternative to the Alchemy deployment system, providing more flexibility in deployment options.