### PR TITLE
Fix migration generation

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -62,7 +62,8 @@ description = "Create new migration"
 run = '''
 MIGRATION_OUTPUT=$(wrangler d1 migrations create sps-db {{arg(name="migration_name")}})
 MIGRATION_FILE=$(echo "$MIGRATION_OUTPUT" | grep -o "prisma/migrations/[0-9]*_.*\.sql" | head -1)
-prisma migrate diff --from-empty --to-schema-datamodel ./prisma/schema.prisma --script --output "$MIGRATION_FILE"
+LATEST_D1_DB=$(find .wrangler/state/v3/d1/miniflare-D1DatabaseObject -name "*.sqlite" -type f -exec ls -t {} + 2>/dev/null | head -1)
+prisma migrate diff --from-url "file:$LATEST_D1_DB" --to-schema-datamodel ./prisma/schema.prisma --script --output "$MIGRATION_FILE"
 '''
 
 [tasks."migrate:dev"]


### PR DESCRIPTION
## Summary

Improves migration generation to diff against the current database state instead of an empty schema. The `migrate:create` task now finds the latest local D1 database file and uses it as the baseline for generating migrations, ensuring that only actual schema changes are included in new migration files. This prevents redundant migration steps and makes the development workflow more efficient when working with an existing database.