### PR TITLE
Add scripts to break down big branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ pnpm-debug.log*
 .vscode/settings.json
 .wrangler
 .claude/*.local.json
+
+# worktrees
+.worktrees/

--- a/mise.toml
+++ b/mise.toml
@@ -77,3 +77,15 @@ run = ["prisma generate", "wrangler d1 migrations apply DB --local"]
 [tasks."migrate:prod"]
 description = "Apply migrations to production"
 run = ["prisma generate", "wrangler d1 migrations apply DB --remote"]
+
+[tasks."split-out"]
+description = "Cherry-pick a commit to main and create a PR"
+run = "bash scripts/cherry-pick-to-main.sh {{arg(name=\"commit\")}}"
+
+[tasks."move-commit"]
+description = "Move a commit from current branch to target branch"
+run = "bash scripts/move-commit.sh {{arg(name=\"commit\")}} {{arg(name=\"target_branch\")}}"
+
+[tasks."cleanup-worktrees"]
+description = "Clean up merged worktrees (use --force to clean all)"
+run = "bash scripts/cleanup-worktrees.sh {{arg(name=\"flags\", default=\"\")}}"

--- a/scripts/cherry-pick-to-main.sh
+++ b/scripts/cherry-pick-to-main.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if commit hash is provided
+if [ $# -eq 0 ]; then
+    echo "Error: Please provide a commit hash"
+    echo "Usage: $0 <commit-hash>"
+    exit 1
+fi
+
+COMMIT_HASH=$1
+WORKTREE_DIR=".worktrees/cherry-pick-$$"
+CURRENT_BRANCH=$(git branch --show-current)
+BRANCH_NAME="cherry-pick-$COMMIT_HASH"
+
+# Validate commit exists
+if ! git rev-parse --verify "$COMMIT_HASH" >/dev/null 2>&1; then
+    echo "Error: Commit $COMMIT_HASH not found"
+    exit 1
+fi
+
+# Get commit message for PR title
+COMMIT_MESSAGE=$(git log --format=%s -n 1 "$COMMIT_HASH")
+
+# Check if the branch already exists and delete it
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+    echo "🗑️  Branch $BRANCH_NAME already exists, deleting..."
+
+    # Check if branch is checked out in any worktree and remove it
+    if git worktree list | grep -q "$BRANCH_NAME"; then
+        echo "🗑️  Removing existing worktree for $BRANCH_NAME..."
+        EXISTING_WORKTREE=$(git worktree list | grep "$BRANCH_NAME" | awk '{print $1}')
+        git worktree remove --force "$EXISTING_WORKTREE"
+    fi
+
+    git branch -D "$BRANCH_NAME"
+fi
+
+# Also delete remote branch if it exists
+if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+    echo "🗑️  Remote branch $BRANCH_NAME already exists, deleting..."
+    git push origin --delete "$BRANCH_NAME"
+fi
+
+echo "🌳 Creating worktree at $WORKTREE_DIR..."
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" main
+
+cd "$WORKTREE_DIR"
+
+echo "🍒 Cherry-picking commit $COMMIT_HASH..."
+if ! git cherry-pick "$COMMIT_HASH"; then
+    echo "❌ Cherry-pick failed. Cleaning up..."
+    cd ..
+    git worktree remove --force "$WORKTREE_DIR"
+    exit 1
+fi
+
+echo "📤 Pushing branch to remote..."
+git push -u origin "$BRANCH_NAME"
+
+echo "🤖 Generating PR summary with Claude Code..."
+# Get the diff to analyze
+DIFF_OUTPUT=$(git diff main..HEAD)
+
+# Use Claude Code to generate a summary
+CLAUDE_SUMMARY=$(claude -p "Please review these changes and write a concise summary for a pull request. Focus on what the changes do and why they're useful. Be specific about the functionality added, modified, or fixed:
+
+$DIFF_OUTPUT" 2>/dev/null || echo "Failed to generate AI summary. Using commit message instead: $COMMIT_MESSAGE")
+
+# Prepare PR body
+PR_BODY="$CLAUDE_SUMMARY"
+
+# Check if PR already exists for this branch
+if gh pr list --head "$BRANCH_NAME" --json number | jq -e '.[0]' >/dev/null 2>&1; then
+    echo "✅ PR already exists for branch $BRANCH_NAME, updating description..."
+    gh pr edit --body "$PR_BODY"
+    PR_URL=$(git config --get remote.origin.url | sed 's/\.git$//' | sed 's/git@github.com:/https:\/\/github.com\//')/pull/$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')
+    echo "📌 PR updated: $PR_URL"
+else
+    echo "🔧 Creating PR with gh CLI..."
+    gh pr create \
+        --base main \
+        --title "$COMMIT_MESSAGE" \
+        --body "$PR_BODY"
+
+    # Get PR URL from output
+    PR_URL=$(git config --get remote.origin.url | sed 's/\.git$//' | sed 's/git@github.com:/https:\/\/github.com\//')/pull/$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')
+    echo "✅ PR created: $PR_URL"
+fi
+
+# Clean up
+cd ../..
+echo "🧹 Cleaning up worktree..."
+git worktree remove "$WORKTREE_DIR"
+
+echo "✨ Done! PR is available at: $PR_URL"

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FORCE_CLEANUP=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force)
+            FORCE_CLEANUP=true
+            shift
+            ;;
+        "")
+            # Handle empty string argument (from mise)
+            shift
+            ;;
+        *)
+            echo "Usage: $0 [--force]"
+            echo "  --force: Clean up all worktrees (not just merged ones)"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if .worktrees directory exists
+if [[ ! -d ".worktrees" ]]; then
+    echo "ℹ️  No .worktrees directory found. Nothing to clean up."
+    exit 0
+fi
+
+# Get list of worktrees (excluding main repository)
+WORKTREES=$(git worktree list --porcelain | grep -E "^worktree " | grep -v "$(git rev-parse --show-toplevel)$" | sed 's/^worktree //' || true)
+
+if [[ -z "$WORKTREES" ]]; then
+    echo "ℹ️  No worktrees found. Nothing to clean up."
+    exit 0
+fi
+
+echo "🔍 Found worktrees to analyze:"
+echo "$WORKTREES" | while read -r worktree; do
+    echo "  - $worktree"
+done
+
+CLEANED_COUNT=0
+
+echo "$WORKTREES" | while read -r worktree; do
+    # Get branch name for this worktree
+    BRANCH=$(git worktree list --porcelain | grep -A1 "^worktree $worktree$" | grep "^branch " | sed 's/^branch refs\/heads\///' || echo "")
+    
+    if [[ -z "$BRANCH" ]]; then
+        echo "⚠️  Could not determine branch for worktree $worktree, skipping..."
+        continue
+    fi
+    
+    if [[ "$FORCE_CLEANUP" == "true" ]]; then
+        echo "🗑️  Force cleaning worktree: $worktree (branch: $BRANCH)"
+        git worktree remove --force "$worktree" 2>/dev/null || true
+        
+        # Also delete the branch if it exists
+        if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+            echo "🗑️  Deleting branch: $BRANCH"
+            git branch -D "$BRANCH" 2>/dev/null || true
+        fi
+        
+        # Delete remote branch if it exists
+        if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "🗑️  Deleting remote branch: $BRANCH"
+            git push origin --delete "$BRANCH" 2>/dev/null || true
+        fi
+        
+        CLEANED_COUNT=$((CLEANED_COUNT + 1))
+    else
+        # Check if branch is merged into main
+        if git merge-base --is-ancestor "$BRANCH" main 2>/dev/null; then
+            echo "✅ Branch $BRANCH is merged into main, cleaning up worktree: $worktree"
+            git worktree remove --force "$worktree" 2>/dev/null || true
+            
+            # Delete the merged branch
+            if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+                echo "🗑️  Deleting merged branch: $BRANCH"
+                git branch -d "$BRANCH" 2>/dev/null || true
+            fi
+            
+            # Delete remote branch if it exists and is merged
+            if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+                echo "🗑️  Deleting merged remote branch: $BRANCH"
+                git push origin --delete "$BRANCH" 2>/dev/null || true
+            fi
+            
+            CLEANED_COUNT=$((CLEANED_COUNT + 1))
+        else
+            echo "⏭️  Branch $BRANCH is not merged into main, skipping worktree: $worktree"
+        fi
+    fi
+done
+
+# Clean up empty .worktrees directory if it exists
+if [[ -d ".worktrees" ]] && [[ -z "$(ls -A .worktrees)" ]]; then
+    echo "🧹 Removing empty .worktrees directory..."
+    rmdir ".worktrees"
+fi
+
+if [[ "$FORCE_CLEANUP" == "true" ]]; then
+    echo "✨ Force cleanup complete! Cleaned up all worktrees."
+else
+    echo "✨ Cleanup complete! Cleaned up $CLEANED_COUNT merged worktrees."
+fi

--- a/scripts/move-commit.sh
+++ b/scripts/move-commit.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if arguments are provided
+if [ $# -lt 2 ]; then
+    echo "Error: Please provide a commit hash and target branch"
+    echo "Usage: $0 <commit-hash> <target-branch>"
+    exit 1
+fi
+
+COMMIT_HASH=$1
+TARGET_BRANCH=$2
+WORKTREE_DIR=".worktrees/move-$$"
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Validate commit exists
+if ! git rev-parse --verify "$COMMIT_HASH" >/dev/null 2>&1; then
+    echo "Error: Commit $COMMIT_HASH not found"
+    exit 1
+fi
+
+# Check if target branch exists
+if ! git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+    # Check if it exists on remote
+    if ! git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
+        echo "Error: Branch '$TARGET_BRANCH' does not exist locally or on remote"
+        exit 1
+    fi
+fi
+
+# Get commit message for PR title
+COMMIT_MESSAGE=$(git log --format=%s -n 1 "$COMMIT_HASH")
+
+echo "🌳 Creating worktree at $WORKTREE_DIR..."
+BRANCH_NAME="move-$COMMIT_HASH-to-${TARGET_BRANCH//\//-}"
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" "$TARGET_BRANCH"
+
+cd "$WORKTREE_DIR"
+
+echo "🍒 Cherry-picking commit $COMMIT_HASH..."
+if ! git cherry-pick "$COMMIT_HASH"; then
+    echo "❌ Cherry-pick failed. Cleaning up..."
+    cd ..
+    git worktree remove --force "$WORKTREE_DIR"
+    exit 1
+fi
+
+echo "📤 Pushing branch to remote..."
+git push -u origin "$BRANCH_NAME"
+
+echo "✅ Commit moved to branch: $BRANCH_NAME"
+
+# Clean up
+cd ../..
+echo "🧹 Cleaning up worktree..."
+git worktree remove "$WORKTREE_DIR"
+
+echo "✨ Done! Commit $COMMIT_HASH has been moved to a new branch based on $TARGET_BRANCH"
+echo "📌 New branch: $BRANCH_NAME"


### PR DESCRIPTION
## Summary

This PR adds tooling to help manage and organize commits across branches in large development workflows. It introduces three new scripts and corresponding mise tasks that streamline common git operations:

### Features Added:

1. **Cherry-pick to main with automated PR creation** (`mise split-out`)
   - Cherry-picks a specific commit from any branch to main
   - Automatically creates a new branch and PR with AI-generated summary
   - Handles existing branches/PRs gracefully by cleaning them up first
   - Uses git worktrees to avoid disrupting current work

2. **Move commits between branches** (`mise move-commit`)
   - Moves a commit from current branch to any target branch
   - Creates a new feature branch based on the target
   - Useful for reorganizing work that belongs on different base branches

3. **Worktree cleanup utility** (`mise cleanup-worktrees`)
   - Automatically cleans up worktrees for merged branches
   - Removes associated local and remote branches
   - Supports `--force` flag to clean all worktrees regardless of merge status
   - Keeps development environment tidy

### Why These Changes Are Useful:

- **Better PR organization**: Easily split large branches into smaller, focused PRs
- **Reduced context switching**: Worktrees allow operations without leaving current branch
- **Automated cleanup**: Prevents accumulation of stale worktrees and branches
- **AI-assisted PR descriptions**: Automatically generates meaningful PR summaries using Claude

The `.gitignore` update ensures worktree directories aren't accidentally committed.