### PR TITLE
use noreply email

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -32,7 +32,7 @@ export const auth = betterAuth({
     magicLink({
       async sendMagicLink({ email, url }) {
         await resend.emails.send({
-          from: "hello@sideprojectsaturday.com",
+          from: "noreply@sideprojectsaturday.com",
           to: email,
           subject: "Sign in to Side Project Saturday",
           react: MagicLinkEmail({ magicLink: url }),
@@ -43,7 +43,7 @@ export const auth = betterAuth({
   emailVerification: {
     async sendVerificationEmail({ user, url }) {
       await resend.emails.send({
-        from: "hello@sideprojectsaturday.com",
+        from: "noreply@sideprojectsaturday.com",
         to: user.email,
         subject: "Verify your email address",
         react: VerificationEmail({ verificationUrl: url, username: user.name }),


### PR DESCRIPTION
## Summary

Updates the email sender address from `hello@sideprojectsaturday.com` to `noreply@sideprojectsaturday.com` for both magic link authentication and email verification emails.

This change clearly indicates these are automated system emails that don't require replies, following email best practices for transactional messages.