### PR TITLE
Make title configurable

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,11 @@
 ---
 import "../styles/global.css";
+
+export interface Props {
+  title?: string;
+}
+
+const { title = "Side Project Saturday" } = Astro.props;
 ---
 
 <!doctype html>
@@ -16,7 +22,7 @@ import "../styles/global.css";
       rel="stylesheet"
     />
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-    <title>Side Project Saturday</title>
+    <title>{title}</title>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## Make title configurable

This PR adds dynamic page title support to the Layout component. The title can now be passed as a prop to the Layout, allowing different pages to have custom titles while maintaining a default value of "Side Project Saturday".

### Changes:
- Added TypeScript interface for Layout props with optional `title` property
- Extracted title from props with default fallback value
- Updated the `<title>` tag to use the dynamic title value

This improves SEO and user experience by allowing pages to display context-specific titles in browser tabs and search results.