### PR TITLE
Fix workflow types

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,9 +1,10 @@
 /// <reference types="astro/client" />
 /// <reference types="@cloudflare/workers-types" />
 
-import type { worker } from "../alchemy.run";
+import type { worker, eventWorker } from "../alchemy.run";
 
 export type WorkerEnv = worker.Env;
+export type WorkflowEnv = eventWorker.Env;
 
 declare module "cloudflare:workers" {
   namespace Cloudflare {
@@ -18,7 +19,7 @@ declare global {
       runtime: {
         env: WorkerEnv;
       };
-      user: import("better-auth").User | null;
+      user: (import("better-auth").User & { role: "admin" | "user" }) | null;
       session: import("better-auth").Session | null;
     }
   }

--- a/src/workflows/event-management.tsx
+++ b/src/workflows/event-management.tsx
@@ -6,20 +6,13 @@ import {
 import { Resend } from "resend";
 import EventInviteEmail from "@/emails/EventInviteEmail";
 import EventTodayEmail from "@/emails/EventTodayEmail";
-
-interface EventWorkflowEnv {
-  DB: D1Database;
-  KV: KVNamespace;
-  RESEND_API_KEY: string;
-  RESEND_AUDIENCE_ID: string;
-  BETTER_AUTH_BASE_URL: string;
-}
+import type { WorkflowEnv } from "@/env";
 
 interface EventWorkflowParams {
   scheduledDate: string; // ISO date string for the event date
 }
 
-export class EventManagementWorkflow extends WorkflowEntrypoint<EventWorkflowEnv> {
+export class EventManagementWorkflow extends WorkflowEntrypoint<WorkflowEnv> {
   async run(
     event: WorkflowEvent<EventWorkflowParams>,
     step: WorkflowStep,
@@ -192,7 +185,7 @@ export class EventManagementWorkflow extends WorkflowEntrypoint<EventWorkflowEnv
 }
 
 export default {
-  scheduled(_: ScheduledController, env: Env, _ctx: ExecutionContext) {
+  scheduled(_: ScheduledController, env: WorkflowEnv, _ctx: ExecutionContext) {
     // Get current UTC time
     const now = new Date();
 


### PR DESCRIPTION
Instead of redefining the workflow types, this pulls them from the alchemy config. Also explicitly adds the `roles` property onto the user types. 