### PR TITLE
Tell claude where to put date logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,7 @@ The app deploys to Cloudflare using Alchemy deployment system configured in `alc
 ## Code Organization and Best Practices
 
 - **Import Paths**: Prefer prefixing esm import paths with `@` which points to the src directory instead of deeply nested relative imports. So `@/lib/auth` instead of `../../lib/auth`
+
+## Utility Patterns
+
+- **Date Calculations**: If you need to calculate a date, add that logic in @src/lib/date-utils.ts. Make sure you check it first to see if what you need already exists.


### PR DESCRIPTION
## Add date utility guidance to CLAUDE.md

This PR adds documentation to guide Claude Code on where to place date-related utility functions in the codebase.

### Changes
- Added a "Utility Patterns" section to CLAUDE.md
- Documented that date calculation logic should go in `@/lib/date-utils.ts`
- Included instruction to check existing utilities before adding new ones

### Why this matters
The Side Project Saturday app has numerous date-related operations (next Saturday calculations, event scheduling, reminder timing, etc.). This change ensures all date utilities are centralized in one location, preventing code duplication and improving maintainability. The existing `date-utils.ts` file already contains 10+ date helper functions, and this documentation ensures future additions follow the same pattern.