### PR TITLE
Fix door buzzer

### DIFF
--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -117,3 +117,18 @@ export function getDayRange(date: Date): { start: Date; end: Date } {
 
 	return { start, end };
 }
+
+/**
+ * Check if current time is within Saturday event hours (9am-12pm EST/EDT)
+ */
+export function isWithinEventHours(date: Date = new Date()): boolean {
+	const nyTime = new Date(
+		date.toLocaleString("en-US", { timeZone: "America/New_York" }),
+	);
+	const day = nyTime.getDay();
+	const hours = nyTime.getHours();
+
+	// Saturday is day 6
+	// Check if it's Saturday and between 9am-12pm EST/EDT
+	return day === 6 && hours >= 9 && hours < 12;
+}

--- a/src/pages/buzz.astro
+++ b/src/pages/buzz.astro
@@ -54,7 +54,6 @@ import Layout from "@/layouts/Layout.astro";
 					<p class="text-gray-600 mb-4">
 						The door can only be opened during Side Project Saturday events.
 					</p>
-					<p class="text-sm text-gray-500">Events run Saturdays 9 AM - 12 PM</p>
 				</div>
 
 				<!-- Error State -->
@@ -174,6 +173,8 @@ import Layout from "@/layouts/Layout.astro";
 </style>
 
 <script>
+	import { isWithinEventHours } from "@/lib/date-utils";
+
 	// State elements
 	const loadingState = document.getElementById("loading-state");
 	const successState = document.getElementById("success-state");
@@ -192,6 +193,13 @@ import Layout from "@/layouts/Layout.astro";
 
 	// Automatically call the buzz API on page load
 	async function buzzDoor() {
+		// First check if we're within event hours
+		if (!isWithinEventHours()) {
+			showState(lockedState);
+			startLockAnimation();
+			return;
+		}
+
 		try {
 			const response = await fetch("/api/buzz", {
 				method: "POST",

--- a/src/pages/buzz.astro
+++ b/src/pages/buzz.astro
@@ -1,17 +1,5 @@
 ---
 import Layout from "@/layouts/Layout.astro";
-import { auth } from "@/lib/auth";
-
-// Check if user is authenticated
-const session = await auth.api.getSession({
-	headers: Astro.request.headers,
-});
-
-// If not authenticated, redirect to login with callback
-if (!session?.user) {
-	const callbackURL = encodeURIComponent(Astro.url.pathname);
-	return Astro.redirect(`/login?callback=${callbackURL}`);
-}
 ---
 
 <Layout title="Buzz In - Side Project Saturday">


### PR DESCRIPTION
There are a few changes here:
1. Drops the auth requirement for the buzzer. I'm likely going to re-add that at some point, but it's too much friction for now. 
2. Instead of checking for an event, the door is just opened on Saturdays during the event time. I'll need to fix this.
3. There's a strange inconsistency where `locals.runtime.env` doesn't actually expose env vars bindings like it's supposed to. Instead I have to use `process.env`. I don't fully understand what's happening here, so that's something to dig further into. 