### PR TITLE
Add buzzer button to homepage for active events

### DIFF
--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,171 @@
+## Detailed Analysis of Current Implementation
+
+Based on my research, here's a comprehensive analysis of the current buzzer implementation and how to integrate a buzzer button into the homepage:
+
+### 1. **Current Buzzer System Architecture**
+
+#### **Buzzer Page (/buzz):**
+- **Automatic trigger**: When users visit `/buzz`, it automatically calls the buzz API
+- **Visual states**: Loading, Success, Locked, and Error states with animations
+- **Time-based check**: Uses `isWithinEventHours()` from date-utils to check if it's Saturday 9am-12pm EST
+- **Countdown feature**: After successful buzz, shows a 10-second countdown before allowing another buzz
+
+#### **Buzzer API (/api/buzz):**
+- **Method**: POST endpoint
+- **Authentication**: No user authentication required (public endpoint)
+- **Validation**: 
+  - Checks if current time is within event hours (Saturday 9am-12pm EST)
+  - Returns 403 if outside event hours
+- **Integration**: Uses SwitchBot API with HMAC authentication to physically unlock the door
+- **Response**: Returns success/failure JSON with appropriate messages
+
+#### **Important Note**: The current implementation only checks time windows, NOT event status (`inprogress`). This is a discrepancy from the documentation.
+
+### 2. **Homepage Structure**
+
+#### **Current Layout:**
+- Gradient background with decorative elements
+- Main title "Side Project Saturday" with time and location
+- Central card containing:
+  - Next event date display
+  - Authentication-dependent sections:
+    - **Authenticated users**: See `AuthenticatedUserSection` with RSVP status, event details, subscription management
+    - **Non-authenticated**: See registration form or magic link sent confirmation
+
+#### **Authentication Flow:**
+- User state from `Astro.locals.user` (set by middleware)
+- User preferences (rsvped, subscribed) fetched from database
+- Checks for scheduled events for next Saturday
+
+### 3. **UI Component Patterns**
+
+#### **Button Styles:**
+- Primary action buttons use gradient backgrounds (amber/orange)
+- Shadow effects for depth
+- Hover animations (scale transform)
+- Consistent rounded corners and padding
+
+#### **Card/Section Patterns:**
+- Colored background boxes (green, blue, amber, purple) for different sections
+- Border styling with matching colors
+- Icon usage for visual clarity
+- Responsive text sizing
+
+### 4. **Missing Pieces for Homepage Integration**
+
+1. **Active Event Detection**: Need to check for events with `status = 'inprogress'`, not just time windows
+2. **Buzzer Button Component**: Need to create a button that fits the existing UI patterns
+3. **Client-Side Interaction**: Need JavaScript to handle the buzz action without page reload
+4. **Visual Feedback**: Loading states and success/error messages inline
+
+### 5. **Recommended Implementation Approach**
+
+#### **Homepage Modifications:**
+1. Add query to check for active events (status = 'inprogress')
+2. Add buzzer button in AuthenticatedUserSection when:
+   - User is authenticated
+   - There's an active event (status = 'inprogress')
+   - Current time is within event hours
+
+#### **Button Placement Options:**
+1. **Option A**: New section below RSVP section in AuthenticatedUserSection
+2. **Option B**: Floating action button in corner of the page
+3. **Option C**: Inline with event details section (recommended)
+
+#### **Technical Implementation:**
+1. Create a new component `BuzzerButton.astro` or add directly to AuthenticatedUserSection
+2. Use HTMX or client-side JavaScript for API calls
+3. Show inline loading/success/error states
+4. Match existing button styling patterns
+
+#### **Security Considerations:**
+- Keep the buzzer API public (as it currently is) since physical access is time-gated
+- Consider rate limiting to prevent abuse
+- Log buzz attempts for security auditing
+
+This analysis provides a complete understanding of the current system and clear direction for integrating the buzzer button into the homepage while maintaining consistency with existing patterns and functionality.
+
+## Authentication and Event Status Analysis
+
+Based on my analysis of the codebase, here are the key authentication and event status patterns:
+
+### 1. **User Authentication State Detection**
+
+- **Middleware Setup**: Authentication is handled in `src/middleware.ts` which:
+  - Initializes `context.locals.user` and `context.locals.session` to null
+  - Uses better-auth to get session from request headers
+  - Sets user data if session exists
+  - Protects admin routes by checking user role
+
+- **Component Access**: Components access auth state via `Astro.locals.user`
+  - Example from homepage: `const user = Astro.locals.user;`
+  - User object contains: id, email, name, role, etc.
+  - Additional preferences (rsvped, subscribed) are fetched from database
+
+### 2. **Event Status Checking**
+
+- **Time-Based Approach**: The app currently uses a **time-based approach** rather than checking event status in the database:
+  - `isWithinEventHours()` function checks if it's Saturday 9am-12pm EST/EDT
+  - The buzzer API (`/api/buzz.ts`) only checks time, not event status
+  - No checks for `event.status === 'inprogress'` in the actual code
+
+- **Event Storage**: Events are stored with status field (scheduled/inprogress/canceled/completed) but:
+  - Homepage checks for `status: "scheduled"` events
+  - Admin dashboard displays event status
+  - But buzzer functionality doesn't verify event status
+
+### 3. **Conditional UI Rendering Patterns**
+
+- **Authentication-Based Rendering**:
+  ```astro
+  {user ? (
+    <AuthenticatedUserSection user={userWithPreferences} hasEvent={hasEvent} />
+  ) : (
+    <RegistrationFormSection />
+  )}
+  ```
+
+- **Event Availability**:
+  - `hasEvent` boolean passed to components
+  - Components show different UI based on event existence
+  - Example: RSVP section shows "No event scheduled" when no event
+
+### 4. **Component State Patterns**
+
+- **Props Pattern**: Components receive user and event state via props
+  ```astro
+  interface Props {
+    user: { ... };
+    hasEvent?: boolean;
+  }
+  ```
+
+- **Database Queries**: Pages fetch event data directly:
+  ```typescript
+  const event = await db.event.findFirst({
+    where: {
+      eventDate: { gte: start, lt: end },
+      status: "scheduled"
+    }
+  });
+  ```
+
+### 5. **Key Findings for Buzzer Implementation**
+
+1. **Authentication**: Check `Astro.locals.user` to determine if user is logged in
+2. **Event Status**: Currently time-based only - might need to add proper event status check
+3. **Conditional Rendering**: Use Astro's conditional rendering with `{condition ? <A /> : <B />}`
+4. **Event Query Pattern**: Query for events with specific date range and status
+5. **Component Structure**: Pass user and hasEvent as props to child components
+
+### Recommendations for Buzzer Button:
+
+1. Show buzzer button only when:
+   - User is authenticated (`Astro.locals.user` exists)
+   - It's within event hours (`isWithinEventHours()` returns true)
+   - Optionally: verify event exists and is active in database
+
+2. Use existing patterns:
+   - Conditional rendering like homepage
+   - Props passing like `AuthenticatedUserSection`
+   - Time checking with `isWithinEventHours()`

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -213,7 +213,7 @@ export const server = {
 					},
 				);
 
-				const result = await response.json();
+				const result = await response.json() as { statusCode: number };
 
 				if (result.statusCode === 100) {
 					return {

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,6 +1,8 @@
+import { createHmac } from "node:crypto";
 import { defineAction } from "astro:actions";
 import { z } from "astro:schema";
 import { createAuth, db } from "../lib/auth";
+import { isWithinEventHours } from "../lib/date-utils";
 
 export const server = {
 	sendMagicLink: defineAction({
@@ -136,6 +138,101 @@ export const server = {
 			} catch (error) {
 				console.error("Toggle RSVP error:", error);
 				throw new Error("Failed to update RSVP status. Please try again.");
+			}
+		},
+	}),
+
+	openDoor: defineAction({
+		accept: "form",
+		input: z.object({}),
+		handler: async (_input, context) => {
+			try {
+				const runtime = context.locals.runtime;
+				if (!runtime?.env) {
+					throw new Error("Runtime environment not available.");
+				}
+
+				// Initialize database
+				db(runtime.env);
+
+				// Check if it's within event hours
+				if (!isWithinEventHours()) {
+					throw new Error(
+						"The door can only be opened on Saturdays from 9 AM to 12 PM EST.",
+					);
+				}
+
+				// Check if there's an active event
+				const activeEvent = await db.event.findFirst({
+					where: {
+						status: "inprogress",
+					},
+				});
+
+				if (!activeEvent) {
+					throw new Error(
+						"The door can only be opened during an active event.",
+					);
+				}
+
+				// Get SwitchBot credentials from environment
+				const token = runtime.env.SWITCHBOT_TOKEN;
+				const secret = runtime.env.SWITCHBOT_KEY;
+				const deviceId = runtime.env.SWITCHBOT_DEVICE_ID;
+
+				if (!token || !secret || !deviceId) {
+					console.error("SwitchBot credentials not configured");
+					throw new Error("Door control is not properly configured.");
+				}
+
+				// Prepare SwitchBot API request
+				const t = Date.now();
+				const nonce = Math.floor(Math.random() * 1000000);
+				const sign = createHmac("sha256", secret)
+					.update(Buffer.from(token + t + nonce, "utf-8"))
+					.digest()
+					.toString("base64");
+
+				// Make request to SwitchBot API
+				const response = await fetch(
+					`https://api.switch-bot.com/v1.1/devices/${deviceId}/commands`,
+					{
+						method: "POST",
+						headers: {
+							Authorization: token,
+							t: t.toString(),
+							nonce: nonce.toString(),
+							sign: sign,
+							"Content-Type": "application/json",
+						},
+						body: JSON.stringify({
+							command: "press",
+							parameter: "default",
+							commandType: "command",
+						}),
+					},
+				);
+
+				const result = await response.json();
+
+				if (result.statusCode === 100) {
+					return {
+						success: true,
+						message: "Door opened successfully! Come on up to the 5th floor.",
+					};
+				} else {
+					console.error("SwitchBot API error:", result);
+					throw new Error(
+						"Failed to open door. Please try again or contact support.",
+					);
+				}
+			} catch (error) {
+				console.error("Open door error:", error);
+				// Re-throw specific error messages
+				if (error instanceof Error) {
+					throw error;
+				}
+				throw new Error("An error occurred while trying to open the door.");
 			}
 		},
 	}),

--- a/src/components/AuthenticatedUserSection.astro
+++ b/src/components/AuthenticatedUserSection.astro
@@ -1,5 +1,6 @@
 ---
 import { actions } from "astro:actions";
+import { isWithinEventHours } from "@/lib/date-utils";
 
 interface Props {
 	user: {
@@ -9,9 +10,16 @@ interface Props {
 		rsvped?: boolean;
 	};
 	hasEvent?: boolean;
+	hasActiveEvent?: boolean;
 }
 
-const { user, hasEvent = true } = Astro.props;
+const { user, hasEvent = true, hasActiveEvent = false } = Astro.props;
+
+// Check if buzzer should be shown
+const showBuzzer = hasActiveEvent && isWithinEventHours();
+
+// Get buzzer action result
+const buzzerResult = Astro.getActionResult(actions.openDoor);
 ---
 
 <div>
@@ -115,6 +123,36 @@ const { user, hasEvent = true } = Astro.props;
 				</form>
 			</div>
 		</div>
+
+		{
+			showBuzzer && (
+				<div class="bg-rose-50 border border-rose-200 rounded-md p-3">
+					<div class="text-sm font-medium text-rose-800 mb-2">
+						Building Access
+					</div>
+					{buzzerResult && !buzzerResult.error ? (
+						<div class="text-green-700 text-sm mb-2">
+							✅ {buzzerResult.data.message}
+						</div>
+					) : buzzerResult?.error ? (
+						<div class="text-red-700 text-sm mb-2">
+							❌ {buzzerResult.error.message}
+						</div>
+					) : null}
+					<form method="POST" action={actions.openDoor}>
+						<button
+							type="submit"
+							class="w-full bg-rose-600 text-white font-medium py-2 px-4 rounded-md hover:bg-rose-700 transition-all"
+						>
+							🚪 Open Building Door
+						</button>
+					</form>
+					<div class="text-xs text-rose-600 mt-2">
+						Press to unlock the building entrance
+					</div>
+				</div>
+			)
+		}
 
 		<form method="POST" action={actions.signOut}>
 			<button

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import {
 	getDayRange,
 	getNextSaturdayDate,
 	getNextSaturdayFormatted,
+	isWithinEventHours,
 } from "@/lib/date-utils";
 import AuthenticatedUserSection from "../components/AuthenticatedUserSection.astro";
 import BackgroundDecorations from "../components/BackgroundDecorations.astro";
@@ -52,6 +53,7 @@ const { start, end } = getDayRange(nextSaturdayDate);
 
 // Check if there's a scheduled event for next Saturday
 let hasEvent = false;
+let hasActiveEvent = false;
 try {
 	db(Astro.locals.runtime.env);
 	const event = await db.event.findFirst({
@@ -64,6 +66,14 @@ try {
 		},
 	});
 	hasEvent = !!event;
+	
+	// Check if there's an active event in progress
+	const activeEvent = await db.event.findFirst({
+		where: {
+			status: "inprogress",
+		},
+	});
+	hasActiveEvent = !!activeEvent;
 } catch (error) {
 	console.error("Error checking for event:", error);
 }
@@ -131,6 +141,7 @@ if (signOutResult && !signOutResult.error) {
 					<AuthenticatedUserSection
 						user={userWithPreferences}
 						hasEvent={hasEvent}
+						hasActiveEvent={hasActiveEvent}
 					/>
 				) : magicLinkResult && !magicLinkResult.error ? (
 					<MagicLinkSentSection message={magicLinkResult.data.message} />

--- a/task.md
+++ b/task.md
@@ -1,18 +1,19 @@
 # Add buzzer button to logged in view for active events
-**Status:** Refining
+**Status:** InProgress
 **Agent PID:** 63934
 
 ## Original Todo
 Add buzzer button to logged in view for active events (Quick access door buzzer on homepage during active events)
 
 ## Description
-[what we're building]
+Add a buzzer button to the homepage for authenticated users during active events. This provides quick access to the building door control without requiring users to navigate to the separate `/buzz` page.
 
 ## Implementation Plan
-[how we are building it]
-- [ ] Code change with location(s) if applicable (src/file.ts:45-93)
-- [ ] Automated test: ...
-- [ ] User test: ...
+- [ ] Check for active events during event hours in the homepage
+- [ ] Add buzzer button form to AuthenticatedUserSection component when conditions are met
+- [ ] Create an Astro Action to handle the buzzer logic server-side
+- [ ] Display success/error states using form action results
+- [ ] Style the button and states to match existing UI patterns
 
 ## Notes
 [Implementation notes]

--- a/task.md
+++ b/task.md
@@ -11,7 +11,7 @@ Add a buzzer button to the homepage for authenticated users during active events
 ## Implementation Plan
 - [x] Check for active events during event hours in the homepage
 - [x] Add buzzer button form to AuthenticatedUserSection component when conditions are met
-- [ ] Create an Astro Action to handle the buzzer logic server-side
+- [x] Create an Astro Action to handle the buzzer logic server-side
 - [ ] Display success/error states using form action results
 - [ ] Style the button and states to match existing UI patterns
 

--- a/task.md
+++ b/task.md
@@ -12,8 +12,8 @@ Add a buzzer button to the homepage for authenticated users during active events
 - [x] Check for active events during event hours in the homepage
 - [x] Add buzzer button form to AuthenticatedUserSection component when conditions are met
 - [x] Create an Astro Action to handle the buzzer logic server-side
-- [ ] Display success/error states using form action results
-- [ ] Style the button and states to match existing UI patterns
+- [x] Display success/error states using form action results
+- [x] Style the button and states to match existing UI patterns
 
 ## Notes
 [Implementation notes]

--- a/task.md
+++ b/task.md
@@ -1,6 +1,6 @@
 # Add buzzer button to logged in view for active events
 **Status:** InProgress
-**Agent PID:** 63934
+**Agent PID:** 79010
 
 ## Original Todo
 Add buzzer button to logged in view for active events (Quick access door buzzer on homepage during active events)
@@ -9,8 +9,8 @@ Add buzzer button to logged in view for active events (Quick access door buzzer 
 Add a buzzer button to the homepage for authenticated users during active events. This provides quick access to the building door control without requiring users to navigate to the separate `/buzz` page.
 
 ## Implementation Plan
-- [ ] Check for active events during event hours in the homepage
-- [ ] Add buzzer button form to AuthenticatedUserSection component when conditions are met
+- [x] Check for active events during event hours in the homepage
+- [x] Add buzzer button form to AuthenticatedUserSection component when conditions are met
 - [ ] Create an Astro Action to handle the buzzer logic server-side
 - [ ] Display success/error states using form action results
 - [ ] Style the button and states to match existing UI patterns

--- a/task.md
+++ b/task.md
@@ -1,5 +1,5 @@
 # Add buzzer button to logged in view for active events
-**Status:** InProgress
+**Status:** AwaitingCommit
 **Agent PID:** 79010
 
 ## Original Todo

--- a/task.md
+++ b/task.md
@@ -1,0 +1,18 @@
+# Add buzzer button to logged in view for active events
+**Status:** Refining
+**Agent PID:** 63934
+
+## Original Todo
+Add buzzer button to logged in view for active events (Quick access door buzzer on homepage during active events)
+
+## Description
+[what we're building]
+
+## Implementation Plan
+[how we are building it]
+- [ ] Code change with location(s) if applicable (src/file.ts:45-93)
+- [ ] Automated test: ...
+- [ ] User test: ...
+
+## Notes
+[Implementation notes]

--- a/todos/done/2025-07-17-19-04-56-add-buzzer-button-to-homepage.md
+++ b/todos/done/2025-07-17-19-04-56-add-buzzer-button-to-homepage.md
@@ -1,5 +1,5 @@
 # Add buzzer button to logged in view for active events
-**Status:** AwaitingCommit
+**Status:** Done
 **Agent PID:** 79010
 
 ## Original Todo


### PR DESCRIPTION
## Summary
• Added buzzer button to homepage for authenticated users during active events
• Provides quick access to building door control without navigating to separate page
• Only displays when event is in-progress and within event hours (Saturday 9-12 PM EST)

## Test plan
- [ ] Verify buzzer button only appears for logged-in users during active events
- [ ] Test button functionality opens building door successfully
- [ ] Confirm proper error handling for invalid time/event status
- [ ] Check UI styling matches existing component patterns

🤖 Generated with [Claude Code](https://claude.ai/code)