### PR TITLE
Don't show next event if one not scheduled

### DIFF
--- a/src/components/NextEventCard.astro
+++ b/src/components/NextEventCard.astro
@@ -5,16 +5,21 @@ import { getEventEndTime, getEventStartTime } from "@/lib/date-utils";
 interface Props {
 	nextEventDate: string;
 	eventForToday?: Event | null;
+	hasEvent?: boolean;
 }
 
-const { nextEventDate, eventForToday } = Astro.props;
+const { nextEventDate, eventForToday, hasEvent = true } = Astro.props;
 
 // Determine the display text based on event status and timing
 let eventLabel = "Next Event";
 let eventDateDisplay = nextEventDate;
 let highlightClass = "text-amber-600";
 
-if (eventForToday) {
+if (!hasEvent) {
+	eventLabel = "Next Event";
+	eventDateDisplay = "No event scheduled yet";
+	highlightClass = "text-gray-500";
+} else if (eventForToday) {
 	const now = new Date();
 	const eventStart = getEventStartTime(eventForToday.eventDate);
 	const eventEnd = getEventEndTime(eventForToday.eventDate);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -135,7 +135,7 @@ if (signOutResult && !signOutResult.error) {
 				background: "rgba(255,255,255,0.85)",
 			}}
 		>
-			<NextEventCard {nextEventDate} {eventForToday} />
+			<NextEventCard {nextEventDate} {eventForToday} {hasEvent} />
 			{
 				userWithPreferences && session ? (
 					<AuthenticatedUserSection


### PR DESCRIPTION
Fixes an issue where it was showing there's an event this week even though there's not one scheduled. 