### PR TITLE
Remove duplicate admin checks from admin routes

### DIFF
--- a/src/pages/admin/events.astro
+++ b/src/pages/admin/events.astro
@@ -3,11 +3,6 @@ import AdminLayout from "@/layouts/AdminLayout.astro";
 import { db } from "@/lib/auth";
 import { getCurrentWeekSaturdayDate } from "@/lib/date-utils";
 
-// Check if user is admin
-if (!Astro.locals.user || Astro.locals.user.role !== "admin") {
-	return Astro.redirect("/");
-}
-
 db(Astro.locals.runtime.env);
 
 // Get current week's Saturday

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -3,11 +3,6 @@ import AdminLayout from "@/layouts/AdminLayout.astro";
 import { db } from "@/lib/auth";
 import { getCurrentWeekSaturdayDate } from "@/lib/date-utils";
 
-// Check if user is admin
-if (!Astro.locals.user || Astro.locals.user.role !== "admin") {
-	return Astro.redirect("/");
-}
-
 db(Astro.locals.runtime.env);
 
 // Get user statistics

--- a/src/pages/admin/settings.astro
+++ b/src/pages/admin/settings.astro
@@ -3,11 +3,6 @@ import BannerControls from "@/components/admin/BannerControls.astro";
 import AdminLayout from "@/layouts/AdminLayout.astro";
 import { db } from "@/lib/auth";
 
-// Check if user is admin
-if (!Astro.locals.user || Astro.locals.user.role !== "admin") {
-	return Astro.redirect("/");
-}
-
 db(Astro.locals.runtime.env);
 
 // Get banner configuration

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -2,11 +2,6 @@
 import AdminLayout from "@/layouts/AdminLayout.astro";
 import { db } from "@/lib/auth";
 
-// Check if user is admin
-if (!Astro.locals.user || Astro.locals.user.role !== "admin") {
-	return Astro.redirect("/");
-}
-
 db(Astro.locals.runtime.env);
 
 const users = await db.user.findMany({

--- a/src/pages/api/admin/update-banner.ts
+++ b/src/pages/api/admin/update-banner.ts
@@ -2,16 +2,11 @@ import type { APIRoute } from "astro";
 import { db } from "@/lib/auth";
 
 export const POST: APIRoute = async ({ request, locals }) => {
-	// Check if user is admin
-	if (!locals.user || locals.user.role !== "admin") {
-		return new Response(JSON.stringify({ error: "Unauthorized" }), {
-			status: 401,
-			headers: { "Content-Type": "application/json" },
-		});
-	}
-
 	try {
-		const { content, enabled } = await request.json();
+		const { content, enabled } = (await request.json()) as {
+			content: string;
+			enabled: boolean | string;
+		};
 
 		// Convert string "true"/"false" to boolean if needed
 		const enabledBool =


### PR DESCRIPTION
## Summary
- Remove duplicative admin authorization checks from individual admin routes since middleware already handles protection for all `/admin` and `/api/admin` paths
- Centralize admin authorization logic in middleware to reduce code duplication and improve maintainability

## Test plan
- [x] Build passes successfully
- [x] Code formatting applied via pre-commit hooks
- [ ] Verify admin routes still require proper authorization
- [ ] Test that non-admin users are still blocked from admin routes

🤖 Generated with [opencode](https://opencode.ai)