### PR TITLE
Add admin user deletion functionality

### DIFF
--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -95,6 +95,7 @@ const verifiedUsers = users.filter((u) => u.emailVerified).length;
 								<th>Subscribed</th>
 								<th>Email Verified</th>
 								<th>Created</th>
+								<th>Actions</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -167,6 +168,22 @@ const verifiedUsers = users.filter((u) => u.emailVerified).length;
 										</td>
 										<td class="text-sm text-gray-500">
 											{new Date(user.createdAt).toLocaleDateString()}
+										</td>
+										<td>
+											<button
+												class="btn btn-error btn-xs"
+												hx-post="/api/admin/delete-user"
+												hx-ext="json-enc"
+												hx-confirm={`Are you sure you want to delete ${user.email}? This action cannot be undone.`}
+												hx-target="closest tr"
+												hx-swap="delete"
+												data-user-id={user.id}
+												hx-vals="js:{userId: event.target.dataset.userId}"
+												hx-on:response-error="alert(event.detail.xhr.responseJSON?.error || 'Failed to delete user')"
+												disabled={user.id === Astro.locals.user?.id}
+											>
+												Delete
+											</button>
 										</td>
 									</tr>
 								))

--- a/src/pages/api/admin/delete-user.ts
+++ b/src/pages/api/admin/delete-user.ts
@@ -1,0 +1,57 @@
+import type { APIRoute } from "astro";
+import { z } from "zod";
+import { db } from "@/lib/auth";
+
+const DeleteUserSchema = z.object({
+	userId: z.string(),
+});
+
+export const POST: APIRoute = async ({ request, locals }) => {
+	try {
+		const body = await request.json();
+		const parseResult = DeleteUserSchema.safeParse(body);
+
+		if (!parseResult.success) {
+			return new Response(
+				JSON.stringify({
+					error: "Invalid request",
+					details: parseResult.error.flatten(),
+				}),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		}
+
+		const { userId } = parseResult.data;
+
+		// Prevent admin from deleting their own account
+		if (userId === locals.user?.id) {
+			return new Response(
+				JSON.stringify({ error: "Cannot delete your own account" }),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		}
+
+		// Delete user
+		db(locals.runtime.env);
+		await db.user.delete({
+			where: { id: userId },
+		});
+
+		return new Response(JSON.stringify({ success: true }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	} catch (error) {
+		console.error("Error deleting user:", error);
+		return new Response(JSON.stringify({ error: "Failed to delete user" }), {
+			status: 500,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+};


### PR DESCRIPTION
## Summary
- Add delete user API endpoint at `/api/admin/delete-user` with proper validation and security checks
- Update admin users page to include delete buttons for each user with confirmation dialogs
- Implement safeguards to prevent admins from deleting their own accounts
- Use HTMX for seamless user deletion with proper error handling

## Test plan
- [ ] Navigate to `/admin/users` and verify delete buttons appear in Actions column
- [ ] Attempt to delete a test user and confirm the confirmation dialog appears
- [ ] Verify user is removed from table after successful deletion  
- [ ] Confirm admin cannot delete their own account (button should be disabled)
- [ ] Test error handling when deletion fails