### PR TITLE
Add automatic development user seeding

### DIFF
--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -1,0 +1,69 @@
+import type { PrismaClient } from "@generated/prisma/client";
+
+export const seedUsers = [
+	{
+		email: "admin@example.com",
+		name: "Admin User",
+		emailVerified: true,
+		role: "admin",
+		subscribed: true,
+		rsvped: false,
+	},
+	{
+		email: "user1@example.com",
+		name: "John Doe",
+		emailVerified: true,
+		subscribed: true,
+		rsvped: true,
+	},
+	{
+		email: "user2@example.com",
+		name: "Jane Smith",
+		emailVerified: true,
+		subscribed: true,
+		rsvped: false,
+	},
+	{
+		email: "user3@example.com",
+		name: "Bob Wilson",
+		emailVerified: true,
+		subscribed: false,
+		rsvped: false,
+	},
+	{
+		email: "banned@example.com",
+		name: "Banned User",
+		emailVerified: true,
+		subscribed: false,
+		rsvped: false,
+		banned: true,
+		banReason: "Inappropriate behavior",
+	},
+];
+
+export async function seedDevelopmentData(client: PrismaClient) {
+	try {
+		console.log("🌱 Seeding development users...");
+
+		for (const userData of seedUsers) {
+			const existingUser = await client.user.findUnique({
+				where: { email: userData.email },
+			});
+
+			if (existingUser) {
+				continue;
+			}
+
+			const user = await client.user.create({
+				data: userData,
+			});
+
+			console.log(`  ✅ Created user: ${user.email} (${user.name})`);
+		}
+
+		console.log("🎉 Development seeding completed!");
+	} catch (error) {
+		console.error("Development seeding failed:", error);
+		// Don't fail the app, just log the error
+	}
+}


### PR DESCRIPTION
## Summary
• Integrates automatic user seeding into the Prisma client initialization
• Seeds development databases with test users (admin, regular users, banned user) 
• Uses dynamic imports to avoid affecting production bundles
• Only runs in development mode via `import.meta.env.DEV` check

## Implementation Details
• **`src/lib/seed.ts`**: Contains seed user data and seeding function
• **`src/lib/auth.ts`**: Triggers seeding when Prisma client is first created
• **Simple approach**: Loop-based with existence checks for reliability
• **Clean separation**: Seeding logic isolated from auth logic

## Test Plan
- [x] Verify seeding only runs in development mode
- [x] Confirm duplicate users are skipped gracefully
- [x] Test integration with existing Prisma client setup
- [x] Validate no impact on production builds
- [x] Check that `mise migrate:dev` works correctly