### PR TITLE
Fix inconsistent subscribed user count in admin dashboard

### DIFF
--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -21,7 +21,7 @@ const users = await db.user.findMany({
 // Get user stats
 const totalUsers = users.length;
 const rsvpedUsers = users.filter((u) => u.rsvped).length;
-const subscribedUsers = users.filter((u) => u.subscribed).length;
+const subscribedUsers = await db.user.count({ where: { subscribed: true } });
 const verifiedUsers = users.filter((u) => u.emailVerified).length;
 ---
 


### PR DESCRIPTION
## Summary
- Fixed inconsistency in how subscribed user counts were calculated between admin dashboard pages
- Updated admin users page to use the same database count query as the main dashboard
- Ensures accurate counting by explicitly checking for `subscribed: true` instead of truthy values

## Test plan
- [x] Verify subscribed count matches between `/admin` and `/admin/users` pages
- [x] Test subscription toggle functionality still works correctly
- [x] Confirm counts update properly when users subscribe/unsubscribe